### PR TITLE
Switch dependency from saz/rsyslog to puppet/rsyslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See `docs/contributing.md` for more details on the steps you shall follow to hav
 See [`metadata.json`](metadata.json). In particular, this module depends on 
 
 * [puppetlabs/stdlib](https://forge.puppetlabs.com/puppetlabs/stdlib)
-* [saz/rsyslog](https://forge.puppetlabs.com/saz/rsyslog)
+* [puppet/rsyslog](https://forge.puppetlabs.com/puppet/rsyslog)
 
 ## Overview and Usage
 

--- a/manifests/server/common.pp
+++ b/manifests/server/common.pp
@@ -36,7 +36,7 @@ class dhcp::server::common {
         require => [
                     Package['dhcpd'],
                     File[$dhcp::params::configdir],
-                    Rsyslog::Snippet['dhcpd']
+                    Rsyslog::Component::Custom_config['dhcpd']
                     ],
     }
 
@@ -52,11 +52,8 @@ class dhcp::server::common {
         fail("dhcp::server 'source' OR 'content' parameter must be set")
     }
 
-    if ! defined(Class['rsyslog::client']) {
-        class { 'rsyslog::client': }
-    }
-    rsyslog::snippet { 'dhcpd':
-        content => "if \$syslogtag contains 'dhcpd' then /var/log/dhcpd.log\n& ~",
+    rsyslog::component::custom_config { 'dhcpd':
+        content => "if \$syslogtag contains 'dhcpd' then /var/log/dhcpd.log\n& ~"
     }
 
     if ($dhcp::server::ensure == 'present') {

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,8 @@
       "version_requirement": ">=4.2.2 <5.0.0"
     },
     {
-      "name": "saz/rsyslog",
-      "version_requirement": ">=5.0.0"
+      "name": "puppet/rsyslog",
+      "version_requirement": ">=4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The module saz/rsyslog is marked for deprecation, switch to puppet/rsyslog.